### PR TITLE
patch/PLAT-000/fix-positional-args-error-on-client-initialisation

### DIFF
--- a/satellitevu/client.py
+++ b/satellitevu/client.py
@@ -18,9 +18,9 @@ class Client:
 
     def __init__(
         self,
-        *,
         client_id: str,
         client_secret: str,
+        *,
         audience: Optional[str] = None,
         cache: Optional[AbstractCache] = None,
         auth_url: Optional[str] = None,


### PR DESCRIPTION
@satellitevu-dale  noticed that initialising the client as written in the docs produced this error:

```
>>> import os
>>> from satellitevu import Client
>>> client = Client(os.getenv("CLIENT_ID"), os.getenv("CLIENT_SECRET"))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: Client.__init__() takes 1 positional argument but 3 were given
>>> 
```

Moving the `*` in the `Client` constructor should allow `client_id` and `client_secret` to be called as positional args instead of keyword