### PR TITLE
Add in-memory cache

### DIFF
--- a/satellitevu/auth/__init__.py
+++ b/satellitevu/auth/__init__.py
@@ -1,4 +1,4 @@
 from .auth import Auth
-from .cache import AbstractCache, AppDirCache
+from .cache import AbstractCache, AppDirCache, MemoryCache
 
-__all__ = ["AbstractCache", "AppDirCache", "Auth"]
+__all__ = ["AbstractCache", "AppDirCache", "Auth", "MemoryCache"]

--- a/satellitevu/auth/cache.py
+++ b/satellitevu/auth/cache.py
@@ -23,6 +23,16 @@ class AbstractCache(ABC):
         pass
 
 
+class MemoryCache(AbstractCache):
+    _items = {}
+
+    def save(self, client_id: str, value: str):
+        self._items[client_id] = value
+
+    def load(self, client_id: str) -> Optional[str]:
+        return self._items.get(client_id)
+
+
 class AppDirCache(AbstractCache):
     """
     File based token cache using an INI file in the user's cache dir or given dir.

--- a/satellitevu/auth/cache_test.py
+++ b/satellitevu/auth/cache_test.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from pyfakefs.fake_filesystem import FakeFilesystem
 
-from .cache import AppDirCache
+from .cache import AppDirCache, MemoryCache
 
 TEST_DIR = Path("/test")
 
@@ -69,3 +69,16 @@ def test_cache_update(fs: FakeFilesystem):
     assert {key: value for key, value in parser.items("test-client")} == {
         "access_token": "bar",
     }
+
+
+def test_memory_cache_empty():
+    cache = MemoryCache()
+
+    assert cache.load("test-client") is None
+
+
+def test_memory_cache():
+    cache = MemoryCache()
+    cache.save("test-client", "bar")
+
+    assert cache.load("test-client") == "bar"


### PR DESCRIPTION
For read-only environments like AWS Lambda provide a in-memory cache.