### PR TITLE
Enable per API and per request auth scopes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,6 @@ repos:
         additional_dependencies:
           - flake8-isort==4.1.1
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort

--- a/satellitevu/apis/archive.py
+++ b/satellitevu/apis/archive.py
@@ -10,7 +10,7 @@ class ArchiveV1(AbstractApi):
     https://api.satellitevu.com/archive/v1/docs.
     """
 
-    _api_path = "archive/v1"
+    api_path = "archive/v1"
 
     def search(
         self,
@@ -58,7 +58,7 @@ class ArchiveV1(AbstractApi):
             criteria.
 
         """
-        url = self._url("/search")
+        url = self.url("/search")
         payload = {
             **kwargs,
             "intersects": intersects,
@@ -75,6 +75,6 @@ class ArchiveV1(AbstractApi):
             ),
         }
 
-        return self._make_request(
+        return self.make_request(
             method="POST", url=url, json={k: v for k, v in payload.items() if v}
         )

--- a/satellitevu/apis/archive.py
+++ b/satellitevu/apis/archive.py
@@ -11,6 +11,7 @@ class ArchiveV1(AbstractApi):
     """
 
     api_path = "archive/v1"
+    scopes = []
 
     def search(
         self,

--- a/satellitevu/apis/base.py
+++ b/satellitevu/apis/base.py
@@ -9,6 +9,7 @@ class AbstractApi(ABC):
     client: AbstractClient
     base_url: str
     api_path: str
+    scopes = []
 
     def __init__(self, client: AbstractClient, base_url: str):
         self.client = client
@@ -21,6 +22,8 @@ class AbstractApi(ABC):
         return urljoin(api_base_url, path.lstrip("/"))
 
     def make_request(self, *args, **kwargs):
+        if "scopes" not in kwargs:
+            kwargs["scopes"] = self.scopes
         response = self.client.request(*args, **kwargs)
 
         if response.status == 401:

--- a/satellitevu/apis/base.py
+++ b/satellitevu/apis/base.py
@@ -14,13 +14,13 @@ class AbstractApi(ABC):
         self.client = client
         self.base_url = base_url
 
-    def _url(self, path: str) -> str:
-        api_base_url = urljoin(self.base_url, self._api_path.lstrip("/"))
+    def url(self, path: str) -> str:
+        api_base_url = urljoin(self.base_url, self.api_path.lstrip("/"))
         if api_base_url[-1] != "/":
             api_base_url += "/"
         return urljoin(api_base_url, path.lstrip("/"))
 
-    def _make_request(self, *args, **kwargs):
+    def make_request(self, *args, **kwargs):
         response = self.client.request(*args, **kwargs)
 
         if response.status == 401:

--- a/satellitevu/apis/base_test.py
+++ b/satellitevu/apis/base_test.py
@@ -1,0 +1,42 @@
+from json import dumps
+from typing import List
+from urllib.parse import parse_qs
+
+from mocket import Mocket, Mocketizer
+from mocket.mockhttp import Entry, Request
+from pytest import mark
+
+from satellitevu.apis.base import AbstractApi
+from satellitevu.auth import Auth
+from satellitevu.http.base import AbstractClient
+
+
+class TestApi(AbstractApi):
+    api_path = "/test"
+    scopes = ["test"]
+
+
+@mark.parametrize("kwargs", ({}, {"scopes": ["foo"]}))
+def test_scopes(kwargs, http_client_class, memory_cache):
+    client: AbstractClient = http_client_class()
+    auth = Auth(
+        client_id="test",
+        client_secret="test",
+        auth_url="http://auth.example.com",
+        cache=memory_cache,
+    )
+    client.set_auth("http://api.example.com", auth)
+    api = TestApi(client, "http://api.example.com")
+
+    Entry.single_register(
+        "POST",
+        "http://auth.example.com/oauth/token",
+        body=dumps({"access_token": "mock-token"}),
+    )
+    Entry.single_register("GET", api.url("/"), body="")
+    with Mocketizer():
+        api.make_request("GET", api.url("/"), **kwargs)
+        requests: List[Request] = Mocket.request_list()
+
+    assert len(requests) == 2
+    assert parse_qs(requests[0].body)["scope"] == kwargs.get("scopes", api.scopes)

--- a/satellitevu/apis/orders.py
+++ b/satellitevu/apis/orders.py
@@ -52,7 +52,7 @@ class OrdersV1(AbstractApi):
     https://api.satellitevu.com/orders/v1/docs.
     """
 
-    _api_path = "orders/v1"
+    api_path = "orders/v1"
 
     def get_order_details(self, order_id: UUID) -> Dict:
         """
@@ -65,8 +65,8 @@ class OrdersV1(AbstractApi):
         Returns:
             A dictionary containing properties of the order.
         """
-        url = self._url(f"/{order_id}")
-        response = self._make_request(method="GET", url=url)
+        url = self.url(f"/{order_id}")
+        response = self.make_request(method="GET", url=url)
 
         if response.status != 200:
             raise Exception(f"Error - {response.status} : {response.text}")
@@ -88,12 +88,12 @@ class OrdersV1(AbstractApi):
             items described with conformity to the STAC specification.
 
         """
-        url = self._url("/")
+        url = self.url("/")
 
         if isinstance(item_ids, str):
             item_ids = [item_ids]
 
-        return self._make_request(method="POST", url=url, json={"item_id": item_ids})
+        return self.make_request(method="POST", url=url, json={"item_id": item_ids})
 
     def item_download_url(
         self,
@@ -113,9 +113,9 @@ class OrdersV1(AbstractApi):
         Returns:
             A dictionary containing the url which the image can be downloaded from.
         """
-        url = self._url(f"/{order_id}/{item_id}/download?redirect=False")
+        url = self.url(f"/{order_id}/{item_id}/download?redirect=False")
 
-        response = self._make_request(method="GET", url=url)
+        response = self.make_request(method="GET", url=url)
         return response.json()
 
     def download_item(self, order_id: UUID, item_id: str, destdir: str) -> str:
@@ -138,7 +138,7 @@ class OrdersV1(AbstractApi):
         """
         item_url = self.item_download_url(order_id, item_id)["url"]
 
-        response = self._make_request(method="GET", url=item_url)
+        response = self.make_request(method="GET", url=item_url)
 
         destfile = os.path.join(destdir, f"{item_id}.zip")
         data = raw_response_to_bytes(response)

--- a/satellitevu/apis/orders.py
+++ b/satellitevu/apis/orders.py
@@ -53,6 +53,7 @@ class OrdersV1(AbstractApi):
     """
 
     api_path = "orders/v1"
+    scopes = []
 
     def get_order_details(self, order_id: UUID) -> Dict:
         """

--- a/satellitevu/http/base.py
+++ b/satellitevu/http/base.py
@@ -1,6 +1,9 @@
 from abc import ABC, abstractmethod, abstractproperty
 from importlib.metadata import version
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Mapping, Optional
+
+if TYPE_CHECKING:
+    from satellitevu import Auth
 
 
 class ResponseWrapper(ABC):
@@ -20,7 +23,7 @@ class AbstractClient(ABC):
     Abstract HTTP client
     """
 
-    _auth: Dict[str, Any]
+    _auth: Dict[str, "Auth"]
 
     def __init__(self):
         self._auth = {}
@@ -41,6 +44,7 @@ class AbstractClient(ABC):
         method: str,
         url: str,
         *,
+        scopes: Iterable[str] = [],
         headers: Optional[Dict] = None,
         data: Optional[Dict] = None,
         json: Optional[Any] = None,
@@ -50,18 +54,25 @@ class AbstractClient(ABC):
     def set_auth(self, base_url: str, auth):
         self._auth[base_url] = auth
 
-    def _set_auth(self, url: str, headers):
+    def _set_auth(
+        self, url: str, headers: Mapping[str, str], scopes: Iterable[str] = []
+    ):
         auth = next((v for k, v in self._auth.items() if url.startswith(k)), None)
         has_auth = next(
             (True for k in headers.keys() if k.lower() == "authorization"), False
         )
         if auth and not has_auth:
-            headers["authorization"] = f"Bearer {auth.token()}"
+            headers["authorization"] = f"Bearer {auth.token(scopes)}"
 
-    def prepare_headers(self, url: str, headers):
+    def prepare_headers(
+        self,
+        url: str,
+        headers: Mapping[str, str],
+        scopes: Iterable[str] = [],
+    ):
         _headers = {**(headers or {})}
 
-        self._set_auth(url, _headers)
+        self._set_auth(url, _headers, scopes)
 
         sv_comment = f"(satellitevu/{version('satellitevu')})"
         _headers["User-Agent"] = f"{self.user_agent} {sv_comment}"

--- a/satellitevu/http/http_test.py
+++ b/satellitevu/http/http_test.py
@@ -1,45 +1,14 @@
-from importlib import import_module
 from importlib.metadata import version
 from json import dumps
 from unittest.mock import Mock
 
 from mocket import Mocket, Mocketizer
 from mocket.mockhttp import Entry
-from pytest import fixture, mark, param, skip
+from pytest import mark, skip
 
 from satellitevu.auth.auth import Auth
 
 from . import ResponseWrapper, UrllibClient
-
-try:
-    from requests import Session as RequestsSession
-except ImportError:
-    RequestsSession = None
-try:
-    from httpx import Client as HttpxClient
-except ImportError:
-    HttpxClient = None
-
-
-@fixture(
-    params=(
-        param("UrllibClient"),
-        param(
-            "requests.RequestsSession",
-            marks=[
-                mark.skipif(RequestsSession is None, reason="requests is not installed")
-            ],
-        ),
-        param(
-            "httpx.HttpxClient",
-            marks=[mark.skipif(HttpxClient is None, reason="httpx is not installed")],
-        ),
-    )
-)
-def http_client_class(request):
-    full_path = f"{__package__}.{request.param}"
-    module = import_module(full_path.rsplit(".", maxsplit=1)[0])
-    return getattr(module, full_path.rsplit(".")[-1])
 
 
 @mark.parametrize("method", ("GET", "POST"))

--- a/satellitevu/http/httpx.py
+++ b/satellitevu/http/httpx.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterable, Optional
 
 from httpx import Client, Response
 from httpx.__version__ import __version__
@@ -35,6 +35,7 @@ class HttpxClient(AbstractClient):
         method: str,
         url: str,
         *,
+        scopes: Iterable[str] = [],
         headers: Optional[Dict] = None,
         data: Optional[Dict] = None,
         json: Optional[Any] = None,
@@ -42,7 +43,7 @@ class HttpxClient(AbstractClient):
         response = self.client.request(
             method=method,
             url=url,
-            headers=self.prepare_headers(url, headers),
+            headers=self.prepare_headers(url, headers, scopes),
             data=data,
             json=json,
         )

--- a/satellitevu/http/requests.py
+++ b/satellitevu/http/requests.py
@@ -1,5 +1,5 @@
 from ast import Dict
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
 
 from requests import Response, Session
 from requests.utils import default_user_agent
@@ -36,6 +36,7 @@ class RequestsSession(AbstractClient):
         method: str,
         url: str,
         *,
+        scopes: Iterable[str] = [],
         headers: Optional[Dict] = None,
         data: Optional[Dict] = None,
         json: Optional[Any] = None,
@@ -43,7 +44,7 @@ class RequestsSession(AbstractClient):
         response = self.session.request(
             method=method,
             url=url,
-            headers=self.prepare_headers(url, headers),
+            headers=self.prepare_headers(url, headers, scopes),
             data=data,
             json=json,
         )

--- a/satellitevu/http/urllib.py
+++ b/satellitevu/http/urllib.py
@@ -1,7 +1,7 @@
 from http.client import HTTPResponse
 from json import dumps, loads
 from sys import version_info
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterable, Optional
 from urllib.error import HTTPError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
@@ -32,11 +32,12 @@ class UrllibClient(AbstractClient):
         method: str,
         url: str,
         *,
+        scopes: Iterable[str] = [],
         headers: Optional[Dict] = None,
         data: Optional[Dict] = None,
         json: Optional[Any] = None,
     ) -> ResponseWrapper:
-        headers = self.prepare_headers(url, headers)
+        headers = self.prepare_headers(url, headers, scopes)
         body = None
         if data:
             body = urlencode(data).encode("utf-8")


### PR DESCRIPTION
- API classes expose `url` and `make_request` methods as well as their `api_path` when a user wants to build requests themselves
- API classes can specify a list of scopes they require in auth token used for their endpoints, which will be used by default unless a scopes list is passed to their `make_request` call